### PR TITLE
Update version of mathjs to 4.0.1

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
   
   <script src="vendors/lodash.js"></script>
   
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/mathjs/3.5.3/math.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/mathjs/4.0.1/math.min.js"></script>
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.1.1/jquery.min.js"></script>
   
   <script src="vendors/jquery-ui/jquery-ui.min.js"></script>


### PR DESCRIPTION
Fixes the issue of having certain fractions (like 1/3) in the row transformation statements.

![image](https://user-images.githubusercontent.com/11802391/38163807-19351fa6-34c8-11e8-94b9-4209e1f4284a.png)
No errors!